### PR TITLE
add network to Invoice

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/LNP-BP"
 keywords = ["bitcoin", "lightning", "lnp-bp", "rgb", "invoice"]
 categories = ["cryptography::cryptocurrencies"]
 readme = "../README.md"
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 name = "invoice"


### PR DESCRIPTION
As discussed on the last dev call this PR proposes to add an optional `chain` field to the invoice which purpose is to allow early detection of chain incompatibilities between sender and receiver.